### PR TITLE
[Fix] 메모리 누수 해결

### DIFF
--- a/include/parsing.h
+++ b/include/parsing.h
@@ -6,7 +6,7 @@
 /*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 12:50:07 by spark2            #+#    #+#             */
-/*   Updated: 2024/01/30 23:36:23 by spark2           ###   ########.fr       */
+/*   Updated: 2024/02/01 13:55:29 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,7 @@ void	parsing(t_game *game, char *argv);
 /* read_map */
 void	check_dir_rgb(char *line, t_game *game, int *count);
 int		check_line(char *line, int line_len, t_game *game);
-int		check_map(char **line, char **map_buf, t_game *game);
+int		check_map(char *line, char **map_buf, t_game *game);
 void	read_map(t_game *game);
 
 /* rgb */

--- a/main.c
+++ b/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yerilee <yerilee@student.42.fr>            +#+  +:+       +#+        */
+/*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/01/15 15:37:09 by yerilee           #+#    #+#             */
-/*   Updated: 2024/01/31 23:05:23 by yerilee          ###   ########.fr       */
+/*   Created: 2024/02/01 13:37:37 by spark2            #+#    #+#             */
+/*   Updated: 2024/02/01 15:28:40 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,5 +40,4 @@ int	main(int argc, char **argv)
 		error("Error\n");
 	parsing(&game, argv[1]);
 	executing(&game);
-	destroy_win(&game);
 }

--- a/parsing/check_map2.c
+++ b/parsing/check_map2.c
@@ -6,7 +6,7 @@
 /*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/30 23:04:22 by spark2            #+#    #+#             */
-/*   Updated: 2024/01/30 23:37:19 by spark2           ###   ########.fr       */
+/*   Updated: 2024/02/01 14:40:14 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -154,6 +154,7 @@ void	check_double_new_line(char	*map)
 				error("Error\nmap\n");
 		i++;
 	}
+	free(temp);
 }
 
 void	check_map2(t_game *game)

--- a/parsing/get_next_line/get_next_line.h
+++ b/parsing/get_next_line/get_next_line.h
@@ -6,7 +6,7 @@
 /*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/16 20:52:12 by spark2            #+#    #+#             */
-/*   Updated: 2024/01/24 15:38:02 by spark2           ###   ########.fr       */
+/*   Updated: 2024/02/01 15:24:54 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,5 +29,6 @@ ssize_t	ft_strchr(const char *s, int c);
 char	*ft_substr(char const *s, size_t start, size_t len);
 char	*ft_strdup(const char *src);
 char	*ft_strjoin(char *s1, char const *s2);
+char	*ft_strjoin2(char *s1, char *s2, int s2_len, int count);
 
 #endif

--- a/parsing/get_next_line/get_next_line_utils.c
+++ b/parsing/get_next_line/get_next_line_utils.c
@@ -6,7 +6,7 @@
 /*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/25 17:46:19 by spark2            #+#    #+#             */
-/*   Updated: 2024/01/30 22:27:56 by spark2           ###   ########.fr       */
+/*   Updated: 2024/02/01 15:24:37 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,4 +112,33 @@ char	*ft_strjoin(char *s1, char const *s2)
 	}
 	str[ft_strlen(s1) + i] = 0;
 	return (str);
+}
+
+char	*ft_strjoin2(char *s1, char *s2, int s2_len, int count)
+{
+	char	*temp;
+	int		i;
+
+	i = 0;
+	temp = (char *)malloc(sizeof(char) * (count + s2_len + 1));
+	if (!temp)
+	{
+		free(s1);
+		return (0);
+	}
+	while (i < count)
+	{
+		temp[i] = s1[i];
+		i++;
+	}
+	i = 0;
+	while (i < s2_len)
+	{
+		temp[count + i] = s2[i];
+		i++;
+	}
+	temp[count + i] = '\0';
+	free(s1);
+	s1 = NULL;
+	return (temp);
 }

--- a/parsing/parsing.c
+++ b/parsing/parsing.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parsing.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yerilee <yerilee@student.42.fr>            +#+  +:+       +#+        */
+/*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 13:02:17 by spark2            #+#    #+#             */
-/*   Updated: 2024/01/31 16:20:39 by yerilee          ###   ########.fr       */
+/*   Updated: 2024/02/01 14:49:04 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,6 @@
 void	parsing(t_game *game, char *argv)
 {
 	init_game(game, argv);
-	game->mlx = mlx_init();
-	if (game->mlx == (void *)0)
-		error("Error\nmlx\n");
-	game->win = mlx_new_window(game->mlx, WIDTH, HEIGHT, "cub3D");
 	read_map(game);
 	if (game->map == (void *)0)
 		error("Error\nmap\n");
@@ -27,6 +23,10 @@ void	parsing(t_game *game, char *argv)
 	init_player(game);
 	init_rgb(game);
 	init_buf(game);
+	game->mlx = mlx_init();
+	if (game->mlx == (void *)0)
+		error("Error\nmlx\n");
+	game->win = mlx_new_window(game->mlx, WIDTH, HEIGHT, "cub3D");
 	game->img->init = mlx_new_image(game->mlx,  WIDTH, HEIGHT);
 	game->img->data = (int *)mlx_get_data_addr(game->img->init, \
 	&(game->img->bpp), &(game->img->size_l), &(game->img->endian));

--- a/parsing/read_map.c
+++ b/parsing/read_map.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   read_map.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yerilee <yerilee@student.42.fr>            +#+  +:+       +#+        */
+/*   By: spark2 <spark2@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 17:11:35 by spark2            #+#    #+#             */
-/*   Updated: 2024/01/31 16:44:51 by yerilee          ###   ########.fr       */
+/*   Updated: 2024/02/01 15:24:02 by spark2           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,19 +66,22 @@ int	check_line(char *line, int line_len, t_game *game)
 	return (1);
 }
 
-int	check_map(char **line, char **map_buf, t_game *game)
+int	check_map(char *line, char **map_buf, t_game *game)
 {
-	if (check_line(*line, ft_strlen(*line), game) == 1)
+	char	*tmp;
+
+	tmp = *map_buf;
+	if (check_line(line, ft_strlen(line), game) == 1)
 	{
-		*map_buf = ft_strjoin(*map_buf, *line);
+		*map_buf = ft_strjoin2(tmp, line, ft_strlen(line), ft_strlen(tmp));
 		return (0);
 	}
 	else
 	{
 		free(*map_buf);
-		free(*line);
+		free(line);
 		*map_buf = NULL;
-		*line = NULL;
+		line = NULL;
 		return (1);
 	}
 }
@@ -102,7 +105,7 @@ void	read_map(t_game *game)
 			check_dir_rgb(line, game, &cnt);
 		else
 		{
-			if (check_map(&line, &map_buf, game) == 1)
+			if (check_map(line, &map_buf, game) == 1)
 				error("invalid input map Error\n");
 		}
 		free(line);


### PR DESCRIPTION
### 해결한 것
- 메모리 누수 해결
  - `check_map` 함수 내 `ft_strjoin` 함수에서 발생하는 메모리 누수 해결
- `invalid map`인 경우, `mlx window` 짧게 실행되고 꺼지는 에러 해결
  - `mlx_init`, `mlx_new_window` 함수 호출 위치 모든 init 마친 후로 변경